### PR TITLE
Prevents that scan breaks due to deleted files.

### DIFF
--- a/src/Melody/Diffcs/Executor.php
+++ b/src/Melody/Diffcs/Executor.php
@@ -14,27 +14,27 @@ use Symfony\Component\Console\Helper\ProgressBar;
 class Executor
 {
     /**
-     * @var type 
+     * @var type
      */
     protected $owner;
     /**
-     * @var type 
+     * @var type
      */
     protected $repository;
     /**
-     * @var type 
+     * @var type
      */
     protected $accessToken;
     /**
-     * @var \Github\Client 
+     * @var \Github\Client
      */
     protected $client;
     /**
-     * @var \League\Flysystem\Filesystem 
+     * @var \League\Flysystem\Filesystem
      */
     protected $filesystem;
     /**
-     * @var type 
+     * @var type
      */
     protected $progress;
 
@@ -132,7 +132,7 @@ class Executor
         $downloadedFiles = [];
 
         foreach ($files as $file) {
-            if (!preg_match('/src\/.*\.php$/', $file['filename'])) {
+            if (!preg_match('/src\/.*\.php$/', $file['filename'] || $file['status'] === "removed")) {
                 continue;
             }
 


### PR DESCRIPTION
This pull request propose to fix an issue for situations when a pull request have a .php file which was deleted on the requested branch.

The problem was that once the file was deleted, there is no file to scan. The library `knplabs/github-api` provides a way to avoid such problems by checking the `status` information for each file.

**Before:**
![evidencia](https://cloud.githubusercontent.com/assets/1259313/6934697/1f7c7c9c-d80f-11e4-882f-1e5cfd44dec3.png)

**After:**
![evidencia2](https://cloud.githubusercontent.com/assets/1259313/6934705/4e282d66-d80f-11e4-82dd-2f27e5c9151e.png)
