### PR TITLE
Bug fix, changes and style

### DIFF
--- a/src/Melody/Diffcs/Command/DiffcsCommand.php
+++ b/src/Melody/Diffcs/Command/DiffcsCommand.php
@@ -106,10 +106,27 @@ class DiffcsCommand extends Command
             $githubPass
         );
 
+        $output->writeln('<fg=white;bg=cyan;options=bold>                               </fg=white;bg=cyan;options=bold>');
+        $output->writeln('<fg=white;bg=cyan;options=bold>  PHP DIFF CS (CODE STANDARD)  </fg=white;bg=cyan;options=bold>');
+        $output->writeln('<fg=white;bg=cyan;options=bold>                               </fg=white;bg=cyan;options=bold>');
+        
+        $output->writeln('');
+        $output->writeln(
+            '<fg=cyan>Project: <options=bold>'
+                .$input->getArgument(self::REPOSITORY_ARGUMENT)
+            .'</options=bold></fg=cyan>'
+        );
+        $output->writeln(
+            '<fg=cyan>Pull Request: <options=bold>#'.$pullRequestId.'</options=bold></fg=cyan>'
+        );
+        $output->writeln('');
+        
         try {
             $results = $executor->execute($pullRequestId);
         } catch (\Exception $e) {
-            die("ERROR: " . $e->getMessage() . PHP_EOL);
+            $output->writeln('<error>ERROR:</error> '.$e->getMessage());
+            
+            die();
         }
 
         if (count($results)) {


### PR DESCRIPTION
- Fixed a bug in `downloadFiles()`: the `if` conditional right at the start of the `foreach` had a terrible bug, which was blocking all files.
  
  Before:
  ![diff1](https://cloud.githubusercontent.com/assets/1259313/7790477/ef55c656-025f-11e5-89ef-84ab7e375288.jpg)
  After:
  ![diff2](https://cloud.githubusercontent.com/assets/1259313/7790479/f451b462-025f-11e5-80b7-86539019d7b1.jpg)
- The progress bar was moved from `downloadFiles()` to `runCodeSniffer()` so then we have now a progress bar displaying the evolution only for the downloaded files.
- Added a fancy output style using Symfony Console component:
  ![output](https://cloud.githubusercontent.com/assets/1259313/7790490/a6c9cdfa-0260-11e5-92ea-d39afcf938b9.png)
