### PR TITLE
Environment: remove Dockerfile from this repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM php:7
-
-RUN curl -LO https://github.com/marcelsud/diffcs/releases/download/v0.2.1/diffcs.phar && chmod +x diffcs.phar && mv diffcs.phar /usr/local/bin/diffcs 
-RUN curl -LO https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar && chmod +x phpcs.phar && mv phpcs.phar /usr/local/bin/phpcs
-
-ENTRYPOINT ["diffcs"]
-CMD ["--help"]


### PR DESCRIPTION
In order to keep things organized, and to enjoy some Docker Hub features as automated builds, it's a good practice to keep things that aren't part of the project (like external dependencies) outside of the VCS.

To achieve this, I suggest the following:

- Keep the Dockerfile in another repository, and use the automated build process provided by Docker Hub.
- Or just publish the image on Docker Hub, by pushing it into your account.

### Ok, this looks fine, but what do I do with my original Dockerfile?

Well, I have some suggestions that you can check [here](https://gist.github.com/devdrops/9330fc784595634ca76380fe9bc8d467) :shipit: 